### PR TITLE
Add script for fetching Amazon top items

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # chatbot
+
+This repository contains a script to fetch the top 5 bestselling products from Amazon Japan.
+
+## Requirements
+
+- Python 3
+- `requests`
+- `beautifulsoup4`
+
+## Usage
+
+Run the script to print the product names:
+
+```bash
+python amazon_top5.py
+```
+
+The script scrapes Amazon's bestseller page and outputs the first five product titles. A network connection is required for the script to work.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ This repository contains a script to fetch the top 5 bestselling products from A
 - `requests`
 - `beautifulsoup4`
 
+Install the dependencies with:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## Usage
 
 Run the script to print the product names:
@@ -17,3 +23,4 @@ python amazon_top5.py
 ```
 
 The script scrapes Amazon's bestseller page and outputs the first five product titles. A network connection is required for the script to work.
+If you see an error or no titles are printed, ensure that the dependencies are installed and that you can access the Amazon Japan website.

--- a/amazon_top5.py
+++ b/amazon_top5.py
@@ -1,0 +1,24 @@
+import os
+import requests
+from bs4 import BeautifulSoup
+
+
+def fetch_top5_products(url="https://www.amazon.co.jp/gp/bestsellers"):
+    response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+    response.raise_for_status()
+    soup = BeautifulSoup(response.text, "html.parser")
+    titles = [span.get_text(strip=True) for span in soup.select("div.p13n-sc-truncated")][:5]
+    return titles
+
+
+def main():
+    try:
+        top5 = fetch_top5_products()
+        for i, title in enumerate(top5, 1):
+            print(f"{i}. {title}")
+    except Exception as e:
+        print("Error fetching products:", e)
+
+
+if __name__ == "__main__":
+    main()

--- a/amazon_top5.py
+++ b/amazon_top5.py
@@ -1,13 +1,38 @@
-import os
 import requests
 from bs4 import BeautifulSoup
 
 
-def fetch_top5_products(url="https://www.amazon.co.jp/gp/bestsellers"):
-    response = requests.get(url, headers={"User-Agent": "Mozilla/5.0"})
+def fetch_top5_products(url: str = "https://www.amazon.co.jp/gp/bestsellers") -> list[str]:
+    """Return the titles of the first five bestselling products on Amazon Japan."""
+
+    headers = {"User-Agent": "Mozilla/5.0"}
+    response = requests.get(url, headers=headers)
     response.raise_for_status()
+
     soup = BeautifulSoup(response.text, "html.parser")
-    titles = [span.get_text(strip=True) for span in soup.select("div.p13n-sc-truncated")][:5]
+    items = soup.select("#zg-ordered-list > li")[:5]
+    titles = []
+    selectors = [
+        "div.p13n-sc-truncated",
+        "div._cDEzb_p13n-sc-css-line-clamp-1_1Fn1y",
+        "div._cDEzb_p13n-sc-css-line-clamp-2_EW94u",
+        "div._cDEzb_p13n-sc-css-line-clamp-3_g3dy1",
+        "span.zg-text-center-align > div:nth-of-type(1)",
+    ]
+
+    for item in items:
+        title = None
+        for sel in selectors:
+            elem = item.select_one(sel)
+            if elem:
+                title = elem.get_text(strip=True)
+                break
+        if title:
+            titles.append(title)
+
+    if not titles:
+        raise ValueError("No product titles found. The page layout may have changed.")
+
     return titles
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add `amazon_top5.py` to scrape Amazon Japan bestseller page
- update README with usage instructions

## Testing
- `python -m py_compile amazon_top5.py`

------
https://chatgpt.com/codex/tasks/task_e_6847ec42bef48325bbfaed18f6a4b7dc